### PR TITLE
Map based dispatcher

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "react-dom": "^15.4.2",
     "tough-cookie-file-store": "^1.1.1",
     "typescript": "^2.2.2",
-    "websocket": "^1.0.24"
+    "websocket": "^1.0.24",
+    "typescript-map":"^0.0.3"
   },
   "devDependencies": {
     "@types/core-js": "^0.9.35",

--- a/src/Spectrum/services/commands.service.ts
+++ b/src/Spectrum/services/commands.service.ts
@@ -51,12 +51,10 @@ export class SpectrumCommands {
         //    let args[] = ... something to get the third-Nth token (command args)
         //
         //    // no regex matching so faster since its a simple compare
-        //    this._commandMap.forEach((value:aSpectrumCommand, key:string)=>{
-        //      if (key === parsedShortCode) {
-        //        value.callback(payload.message, lobby, parsedCommand.args);
-        //        return;
-        //      }
-        //    });
+        //    if (this._commandMap.has(parsedShortCode)) {
+        //      this._commandMap[parsedShortCode].callback(payload.message, lobby, args);
+        //      return;
+        //    }
         //  }
 
         this._commandMap.forEach((value:aSpectrumCommand, key:string)=>{


### PR DESCRIPTION
Rather than iterating over lists, you could just add the commands in a map. Its more scalable, and a bit faster than doing a regex on every command. Overall I think the args parsing should be separated and just passed in rather than relying on the "matches" regex result. Prefix and shortCode should be static, and so dont need the regex. The args are all tokens after the prefix and shortcode and should just be passed into the command's callback as an array or other structure. if the command needs to do something with regex then fine, but thats in the command, not the dispatcher.